### PR TITLE
Remove UPX settings from .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,15 +63,6 @@ checksum:
 changelog:
   disable: true
 
-upx:
-  - enabled: true
-    goos:
-      - linux
-      - windows
-    compress: best
-    lzma: true
-    brute: false
-
 report_sizes: true
 
 release:


### PR DESCRIPTION
Removed UPX compression settings from the configuration.